### PR TITLE
Added a variable for specifying additional secret names.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -42,8 +42,13 @@ locals {
         "batcave/defectdojo-rabbitmq-specific",
         "batcave/defectdojo-redis-specific"
     ]
-    include_gitlab_secrets     = var.enable_gitlab_secret_arns == true ? concat(local.secret_names, local.gitlab_secret_names) : local.secret_names
-    all_secret_names           = var.enable_defectdojo_secret_arns == true ? concat(local.include_gitlab_secrets, local.defectdojo_secret_names) : local.include_gitlab_secrets
+    include_gitlab_secrets = var.enable_gitlab_secret_arns == true ? concat(local.secret_names, local.gitlab_secret_names) : local.secret_names
+
+    all_secret_names = (
+      var.enable_defectdojo_secret_arns == true ?
+        concat(local.include_gitlab_secrets, local.defectdojo_secret_names, var.additional_secret_names) :
+        concat(local.include_gitlab_secrets, var.additional_secret_names)
+    )
 }
 
 output "secret_arns"{

--- a/variables.tf
+++ b/variables.tf
@@ -60,13 +60,21 @@ variable "external_secrets_service_accounts" {
 }
 
 variable "enable_gitlab_secret_arns" {
-  type    = bool
-  default = false
+  description = "DEPRECATED: when set to true enables creation of IAM policies for GitLab secrets. Use additional_secret_names instead."
+  type        = bool
+  default     = false
 }
 
 variable "enable_defectdojo_secret_arns" {
-  type    = bool
-  default = false
+  description = "DEPRECATED: when set to true enables creation of IAM policies for DefectDojo secrets. Use additional_secret_names instead."
+  type        = bool
+  default     = false
+}
+
+variable "additional_secret_names" {
+  description = "A list of additional secret names to create IAM policies for."
+  type        = list(string)
+  default     = []
 }
 
 variable "aws_region" {


### PR DESCRIPTION
Flags for enabling IAM policies for predefined app specific secrets are now deprecated.

## Description:

Previously, the introduction of new secrets for a shared service or optional component required modifying this module. With this change that approach is deprecated (but still functional for backward compatibility), and it is now possible to provide an arbitrary list of secrets.

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [X] No security impacts identified.

